### PR TITLE
Fix rails 6 autoload deprecation notices

### DIFF
--- a/lib/jquery/modal/filters.rb
+++ b/lib/jquery/modal/filters.rb
@@ -5,5 +5,6 @@ module Jquery
   end
 end
 
-
-ActionController::Base.send :include, Jquery::Filters
+ActiveSupport.on_load(:action_controller) do
+  include Jquery::Filters
+end

--- a/lib/jquery/modal/helpers.rb
+++ b/lib/jquery/modal/helpers.rb
@@ -6,4 +6,6 @@ module Jquery
   end
 end
 
-ActionView::Base.send :include, Jquery::Helpers
+ActiveSupport.on_load(:action_view) do
+  include Jquery::Helpers
+end


### PR DESCRIPTION
* https://github.com/rails/rails/issues/36546
* Referencing ActionController::Base in rails initialization causes
  deprecation notices
* Use ActiveSupport.on_load to include helpers without referencing
  ActionController::Base